### PR TITLE
Implement a preprocessor to handle inline stem macro

### DIFF
--- a/asciidoctor-mathematical.gemspec
+++ b/asciidoctor-mathematical.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.description = "Converts latexmath equations in Asciidoctor to SVG"
   s.authors     = ["Tobias Stumm"]
   s.email       = 'tstumm@users.noreply.github.com'
-  s.files       = ["lib/asciidoctor-mathematical", "lib/asciidoctor-mathematical/extension.rb"]
+  s.files       = ["lib/asciidoctor-mathematical", "lib/asciidoctor-mathematical/extension.rb", "lib/asciidoctor-mathematical.rb"]
   s.homepage    =
     'https://github.com/tstumm/asciidoctor-mathematical'
   s.license       = 'MIT'

--- a/lib/asciidoctor-mathematical.rb
+++ b/lib/asciidoctor-mathematical.rb
@@ -1,5 +1,6 @@
 RUBY_ENGINE == 'opal' ? (require 'asciidoctor-mathematical/extension') : (require_relative 'asciidoctor-mathematical/extension')
 
 Extensions.register do
+  preprocessor MathematicalPreprocessor
   treeprocessor MathematicalTreeprocessor
 end

--- a/lib/asciidoctor-mathematical/extension.rb
+++ b/lib/asciidoctor-mathematical/extension.rb
@@ -17,9 +17,9 @@ class MathematicalTreeprocessor < Extensions::Treeprocessor
         end
       end
       image_postfix = ".#{format}"
-      scale = "100%"
+      scale = 1.0
       if format == :png
-        scale = "#{72.0/300.0*100}%"
+        scale = 72.0/300.0
       end
       ppi = 72.0
       if format == :png
@@ -52,7 +52,11 @@ class MathematicalTreeprocessor < Extensions::Treeprocessor
         result = mathematical.parse equation_data
         ::IO.write image_file, result[:data]
 
-        attrs = { 'target' => image_target, 'alt' => alt_text, 'align' => 'center', 'width' => scale}
+        attrs = { 'target' => image_target, 'alt' => alt_text, 'align' => 'center' }
+        if format == :png
+          attrs['width'] = "#{result[:width]}pt"
+          attrs['height'] = "#{result[:height]}pt"
+        end
         parent = stem.parent
         stem_image = create_image_block parent, attrs
         stem_image.id = stem.id if stem.id

--- a/sample.adoc
+++ b/sample.adoc
@@ -1,6 +1,6 @@
 = _Precompiled_ Math!
 :math:
-:imagesoutdir: generated-images
+:imagesoutdir: images
 
 ## Equations!
 
@@ -9,11 +9,11 @@
 k_{n+1} = n^2 + k_n^2 - k_{n-1}
 ++++
 
-Some useful text!
-
-Formula for quadratic root:
+Some useful text! Formula for quadratic root:
 
 [latexmath]
 ++++
 x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}
 ++++
+
+Inline equation works too! latexmath:[a^2+b^2=c^2]. Pretty nice, huh?

--- a/sample.adoc
+++ b/sample.adoc
@@ -3,8 +3,17 @@
 :imagesoutdir: generated-images
 
 ## Equations!
+
 [latexmath]
 ++++
 k_{n+1} = n^2 + k_n^2 - k_{n-1}
 ++++
+
 Some useful text!
+
+Formula for quadratic root:
+
+[latexmath]
+++++
+x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}
+++++


### PR DESCRIPTION
This pull requests implement the following functionality:
1. Implement higher resolution PNG support
2. Implement a preprocessor to handle inline stem.
3. Fix missing files in gem.

Currently, asciidoctor-mathematical generate PNG images with default PPI (72), which is pretty low. Higher PPI can result in better looking pages. One may question why not use SVG. It simply because Word does not support SVG and I use asciidoc -> docbook -> docx for my technical documents (I like PDF, but I am required to use word :( ). This commit uses the following method:
1. Generate png images at 300 PPI.
2. Scale PNG images to the pt resolution returned by mathematical.

Another problem of asciidoctor-mathematical is that it does not support inline stem. This dues partially to the inablility to override standard inline macros in asciidoctor. So I implement an asciidoctor preprocessor  to change inline stem (currently only latexmath stem) to inline image and generate the image with mathematical. It is not perfect, but it works and I can now use asciidoctor for my papers.

I appreciate any comments on these commits. If accepted, I would suggest we submit a version to rubygems.org so everyone can benifit.