### PR TITLE
Fix unrecongonized '<>&' in inline latexmath

### DIFF
--- a/lib/asciidoctor-mathematical/extension.rb
+++ b/lib/asciidoctor-mathematical/extension.rb
@@ -136,7 +136,7 @@ class MathematicalPreprocessor < Extensions::Preprocessor
       while md
         stem_content = md[1]
         # NOTE: It seems that we need to escape '<>&' to make mathematical
-        # work. This is wired but verified. So we escape them here.
+        # work. This is weired but verified. So we escape them here.
         stem_content = sub_specialchars stem_content
         equation_data = %($#{stem_content}$)
         stem_id = %(stem-#{::Digest::MD5.hexdigest stem_content})


### PR DESCRIPTION
It's reported at https://github.com/asciidoctor/asciidoctor-pdf/issues/45 that inline latexmath such as `latexmath:[a < b]` does not work (the block macros work well). It's actually caused by unescaped '<>&' chars feed to mathematical. This commit fixes it by escaping these chars.