### PR TITLE
resolves #11 process inline stem macro using Treeprocessor

### DIFF
--- a/lib/asciidoctor-mathematical.rb
+++ b/lib/asciidoctor-mathematical.rb
@@ -1,6 +1,5 @@
-RUBY_ENGINE == 'opal' ? (require 'asciidoctor-mathematical/extension') : (require_relative 'asciidoctor-mathematical/extension')
+require_relative 'asciidoctor-mathematical/extension'
 
-Extensions.register do
-  preprocessor MathematicalPreprocessor
+Asciidoctor::Extensions.register do
   treeprocessor MathematicalTreeprocessor
 end


### PR DESCRIPTION
- process the inline stem macro using a Treeprocessor
- remove Preprocessor
- remove require condition for Opal (not relevant)
- don't include Asciidoctor module in extension
- consolidate code to resolve format, scale, and ppi values
- autoload Mathematical
- use mkdir_p from Asciidoctor::Helpers to avoid loading FileUtils
- minor optimizations and coding style refinements